### PR TITLE
Update tsconfig to build es modules so it works with wrangler project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "applicationinsights-cloudflareworkers",
-  "version": "0.0.14",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ESNext",
-		"module": "CommonJS",
+		"module": "ESNext",
 		"declaration": true,
 		"moduleResolution": "node",
 		"outDir": "dist",


### PR DESCRIPTION
The Cloudflare wrangler CLI creates projects with the the module format specified as `esnext`. When building the library with `CommonJS` and consuming it in the default wrangler project you get:

> src/index.ts → build/index.js...
(!) Error when using sourcemap for reporting an error: Can't resolve original location of error.
src\helpers\logger.ts: (1:9)
[!] Error: 'ApplicationInsights' is not exported by node_modules\applicationinsights-cloudflareworkers\dist\src\index.js, imported by src\helpers\logger.ts
https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module

Changing the module format in the library to `ESNext`:

> src/index.ts → build/index.js...
created build/index.js in 2.2s