### PR TITLE
Add connection string support

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
-      - run: npm test
 
   publish-npm:
     needs: build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Application Insights Cloudflareworkers
 
-*This is a fork that adds rudimentary connection string support*
+***This is a fork that adds rudimentary connection string support***
 
 Note: Still a work in progress. This package might still have breaking changes
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Application Insights Cloudflareworkers
 
+*This is a fork that adds rudimentary connection string support*
+
 Note: Still a work in progress. This package might still have breaking changes
 
 Provides application insights functionality in cloudflare workers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "applicationinsights-cloudflareworkers-modern",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "applicationinsights-cloudflareworkers-modern",
-			"version": "0.2.10",
+			"version": "0.2.11",
 			"license": "ISC",
 			"devDependencies": {
+				"@types/node": "^20.14.10",
 				"@typescript-eslint/eslint-plugin": "^2.7.0",
 				"@typescript-eslint/parser": "2.15.0",
 				"eslint": "^6.8.0",
@@ -101,6 +102,15 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
 			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "20.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "2.34.0",
@@ -3428,6 +3438,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3626,6 +3642,15 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
 			"dev": true
+		},
+		"@types/node": {
+			"version": "20.14.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+			"dev": true,
+			"requires": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "2.34.0",
@@ -6121,6 +6146,12 @@
 				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			}
+		},
+		"undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
 		},
 		"uri-js": {
 			"version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-	"name": "applicationinsights-cloudflareworkers",
+	"name": "applicationinsights-cloudflareworkers-modern",
 	"version": "0.2.10",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "applicationinsights-cloudflareworkers-modern",
 			"version": "0.2.10",
 			"license": "ISC",
 			"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
 	"name": "applicationinsights-cloudflareworkers-modern",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "applicationinsights-cloudflareworkers-modern",
-			"version": "0.2.11",
+			"version": "0.2.12",
 			"license": "ISC",
 			"devDependencies": {
-				"@types/node": "^20.14.10",
 				"@typescript-eslint/eslint-plugin": "^2.7.0",
 				"@typescript-eslint/parser": "2.15.0",
 				"eslint": "^6.8.0",
@@ -102,15 +101,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
 			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "20.14.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
-			"dev": true,
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "2.34.0",
@@ -3438,12 +3428,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
-		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3642,15 +3626,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
 			"dev": true
-		},
-		"@types/node": {
-			"version": "20.14.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-			"integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
-			"dev": true,
-			"requires": {
-				"undici-types": "~5.26.4"
-			}
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "2.34.0",
@@ -6146,12 +6121,6 @@
 				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			}
-		},
-		"undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
 		},
 		"uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "applicationinsights-cloudflareworkers-modern",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "",
 	"main": "./dist/cjs/src/index.js",
 	"module": "./dist/mjs/src/index.mjs",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	},
 	"homepage": "https://github.com/H-Finch-404/applicationinsights-cloudflareworkers#readme",
 	"devDependencies": {
+		"@types/node": "^20.14.10",
 		"@typescript-eslint/eslint-plugin": "^2.7.0",
 		"@typescript-eslint/parser": "2.15.0",
 		"eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "applicationinsights-cloudflareworkers",
+	"name": "applicationinsights-cloudflareworkers-modern",
 	"version": "0.2.10",
 	"description": "",
 	"main": "./dist/cjs/src/index.js",
@@ -15,19 +15,19 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/sazzy4o/applicationinsights-cloudflareworkers.git"
+		"url": "git+https://github.com/H-Finch-404/applicationinsights-cloudflareworkers.git"
 	},
 	"keywords": [
 		"cloudflareworkers",
 		"applicationinsights",
 		"cloudflare"
 	],
-	"author": "Spencer von der Ohe",
+	"author": "Wietse.DeKoninck",
 	"license": "ISC",
 	"bugs": {
-		"url": "https://github.com/sazzy4o/applicationinsights-cloudflareworkers/issues"
+		"url": "https://github.com/H-Finch-404/applicationinsights-cloudflareworkers/issues"
 	},
-	"homepage": "https://github.com/sazzy4o/applicationinsights-cloudflareworkers#readme",
+	"homepage": "https://github.com/H-Finch-404/applicationinsights-cloudflareworkers#readme",
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^2.7.0",
 		"@typescript-eslint/parser": "2.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "applicationinsights-cloudflareworkers-modern",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"description": "",
 	"main": "./dist/cjs/src/index.js",
 	"module": "./dist/mjs/src/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "applicationinsights-cloudflareworkers-modern",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "",
 	"main": "./dist/cjs/src/index.js",
 	"module": "./dist/mjs/src/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "applicationinsights-cloudflareworkers-modern",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "",
 	"main": "./dist/cjs/src/index.js",
 	"module": "./dist/mjs/src/index.mjs",
@@ -29,7 +29,6 @@
 	},
 	"homepage": "https://github.com/H-Finch-404/applicationinsights-cloudflareworkers#readme",
 	"devDependencies": {
-		"@types/node": "^20.14.10",
 		"@typescript-eslint/eslint-plugin": "^2.7.0",
 		"@typescript-eslint/parser": "2.15.0",
 		"eslint": "^6.8.0",

--- a/src/ApplicationInsights.ts
+++ b/src/ApplicationInsights.ts
@@ -2,20 +2,30 @@ import { Domain } from './types/Domain'
 import { Envelope } from './types/Envelope'
 
 export interface ApplicationInsightsOptions {
-	instrumentationKey: string
+	connection: ApplicationInsightsConnection
 	context: object
+}
+// Define the interface with camelCase fields and optional fields
+interface ApplicationInsightsConnection {
+	instrumentationKey: string;
+	endpointSuffix?: string
+	ingestionEndpoint?: string;
+	liveEndpoint?: string;
+	profilerEndpoint?: string;
+	snapshotEndpoint?: string;
 }
 
 export class ApplicationInsights {
+	private DEFAULT_INGESTION_ENDPOINT = "dc.applicationinsights.azure.com"
 	public context: object
 
-	private ikey: string
+	private connection: ApplicationInsightsConnection
 
 	private envelopes: Envelope[]
 
 	constructor(options: ApplicationInsightsOptions) {
 		this.envelopes = []
-		this.ikey = options.instrumentationKey
+		this.connection = options.connection
 		this.context = options.context || {}
 	}
 
@@ -27,15 +37,14 @@ export class ApplicationInsights {
 	*/
 	trackData(baseData: Domain, type?:string) {
 		const baseType = type || baseData.constructor.name
-		const ikeySimple = this.ikey.replace(/-/g, '')
 		const envelope = new Envelope({
 			data: {
 				baseType,
 				baseData,
 			},
 			time: new Date().toISOString(),
-			name: `Microsoft.ApplicationInsights.${ikeySimple}.${baseType}`,
-			iKey: this.ikey,
+			name: `Microsoft.ApplicationInsights.${this.connection.instrumentationKey}.${baseType}`,
+			iKey: this.connection.instrumentationKey,
 			tags: this.context,
 		})
 		this.envelopes.push(envelope)
@@ -45,9 +54,51 @@ export class ApplicationInsights {
 	 * Sends all tracked items to application insights
 	*/
 	async flush() {
-		return fetch('https://dc.services.visualstudio.com/v2/track', {
+		let ingestionEndpoint = this.connection.ingestionEndpoint
+		if (!ingestionEndpoint) {
+			if (this.connection.endpointSuffix) {
+				ingestionEndpoint = `dc.${this.connection.endpointSuffix}`
+			} else {
+				ingestionEndpoint = this.DEFAULT_INGESTION_ENDPOINT
+			}
+		}
+		return fetch(ingestionEndpoint, {
 			method: 'POST',
 			body: JSON.stringify(this.envelopes),
 		})
+	}
+
+	// Function to parse the connection string
+	private static parseConnectionString(connectionString: string): ApplicationInsightsConnection {
+		// Split the connection string by semicolon
+		const parts = connectionString.split(';').filter(part => part.trim() !== '');
+
+		// Initialize an empty object to store the parsed values
+		const parsed: Partial<ApplicationInsightsConnection> = {};
+
+		// Map keys from PascalCase to camelCase
+		const keyMapping: { [key: string]: keyof ApplicationInsightsConnection } = {
+			InstrumentationKey: 'instrumentationKey',
+			IngestionEndpoint: 'ingestionEndpoint',
+			EndpointSuffix: 'endpointSuffix',
+			LiveEndpoint: 'liveEndpoint',
+			ProfilerEndpoint: 'profilerEndpoint',
+			SnapshotEndpoint: 'snapshotEndpoint',
+		};
+
+		// Iterate through each part and extract key-value pairs
+		for (const part of parts) {
+			const [key, value] = part.split('=');
+			if (key && value && keyMapping[key]) {
+				parsed[keyMapping[key]] = value;
+			}
+		}
+
+		// Type assertion to ensure the parsed object conforms to the ConnectionString interface
+		if (parsed.instrumentationKey) {
+			return parsed as ApplicationInsightsConnection;
+		} else {
+			throw new Error("Invalid connection string format: missing instrumentationKey");
+		}
 	}
 }

--- a/src/ApplicationInsights.ts
+++ b/src/ApplicationInsights.ts
@@ -69,7 +69,7 @@ export class ApplicationInsights {
 	}
 
 	// Function to parse the connection string
-	private static parseConnectionString(connectionString: string): ApplicationInsightsConnection {
+	static parseConnectionString(connectionString: string): ApplicationInsightsConnection {
 		// Split the connection string by semicolon
 		const parts = connectionString.split(';').filter(part => part.trim() !== '');
 

--- a/src/ApplicationInsights.ts
+++ b/src/ApplicationInsights.ts
@@ -1,22 +1,14 @@
 import { Domain } from './types/Domain'
 import { Envelope } from './types/Envelope'
+import { ApplicationInsightsConnection } from './ApplicationInsightsConnection'
 
 export interface ApplicationInsightsOptions {
 	connection: ApplicationInsightsConnection
 	context: object
 }
 // Define the interface with camelCase fields and optional fields
-interface ApplicationInsightsConnection {
-	instrumentationKey: string;
-	endpointSuffix?: string
-	ingestionEndpoint?: string;
-	liveEndpoint?: string;
-	profilerEndpoint?: string;
-	snapshotEndpoint?: string;
-}
 
 export class ApplicationInsights {
-	private DEFAULT_INGESTION_ENDPOINT = "dc.applicationinsights.azure.com"
 	public context: object
 
 	private connection: ApplicationInsightsConnection
@@ -54,51 +46,11 @@ export class ApplicationInsights {
 	 * Sends all tracked items to application insights
 	*/
 	async flush() {
-		let ingestionEndpoint = this.connection.ingestionEndpoint
-		if (!ingestionEndpoint) {
-			if (this.connection.endpointSuffix) {
-				ingestionEndpoint = `dc.${this.connection.endpointSuffix}`
-			} else {
-				ingestionEndpoint = this.DEFAULT_INGESTION_ENDPOINT
-			}
-		}
-		return fetch(ingestionEndpoint, {
+		return fetch(this.connection.fullIngestionEndpoint, {
 			method: 'POST',
 			body: JSON.stringify(this.envelopes),
 		})
 	}
 
 	// Function to parse the connection string
-	static parseConnectionString(connectionString: string): ApplicationInsightsConnection {
-		// Split the connection string by semicolon
-		const parts = connectionString.split(';').filter(part => part.trim() !== '');
-
-		// Initialize an empty object to store the parsed values
-		const parsed: Partial<ApplicationInsightsConnection> = {};
-
-		// Map keys from PascalCase to camelCase
-		const keyMapping: { [key: string]: keyof ApplicationInsightsConnection } = {
-			InstrumentationKey: 'instrumentationKey',
-			IngestionEndpoint: 'ingestionEndpoint',
-			EndpointSuffix: 'endpointSuffix',
-			LiveEndpoint: 'liveEndpoint',
-			ProfilerEndpoint: 'profilerEndpoint',
-			SnapshotEndpoint: 'snapshotEndpoint',
-		};
-
-		// Iterate through each part and extract key-value pairs
-		for (const part of parts) {
-			const [key, value] = part.split('=');
-			if (key && value && keyMapping[key]) {
-				parsed[keyMapping[key]] = value;
-			}
-		}
-
-		// Type assertion to ensure the parsed object conforms to the ConnectionString interface
-		if (parsed.instrumentationKey) {
-			return parsed as ApplicationInsightsConnection;
-		} else {
-			throw new Error("Invalid connection string format: missing instrumentationKey");
-		}
-	}
 }

--- a/src/ApplicationInsightsConnection.ts
+++ b/src/ApplicationInsightsConnection.ts
@@ -1,0 +1,69 @@
+interface ApplicationInsightsConnectionStringValues {
+	endpointSuffix?: string
+
+	ingestionEndpoint?: string
+
+	instrumentationKey: string
+
+	liveEndpoint?: string
+
+	profilerEndpoint?: string
+
+	snapshotEndpoint?: string
+}
+
+export class ApplicationInsightsConnection {
+	private static DEFAULT_INGESTION_ENDPOINT_BASE = 'https://dc.applicationinsights.azure.com/'
+
+	public readonly instrumentationKey: string
+
+	public readonly fullIngestionEndpoint?: string
+
+	private constructor(instrumentationKey: string, ingestionEndpoint?: string) {
+		this.instrumentationKey = instrumentationKey
+		this.fullIngestionEndpoint = ingestionEndpoint
+	}
+
+	static fromConnectionString(connectionString: string): ApplicationInsightsConnection {
+		// Split the connection string by semicolon
+		const parts = connectionString.split(';')
+			.filter((part) => part.trim() !== '')
+
+		// Initialize an empty object to store the parsed values
+		const parsed: Partial<ApplicationInsightsConnectionStringValues> = {}
+
+		// Map keys from PascalCase to camelCase
+		const keyMapping: { [key: string]: keyof ApplicationInsightsConnectionStringValues } = {
+			InstrumentationKey: 'instrumentationKey',
+			IngestionEndpoint: 'ingestionEndpoint',
+			EndpointSuffix: 'endpointSuffix',
+			LiveEndpoint: 'liveEndpoint',
+			ProfilerEndpoint: 'profilerEndpoint',
+			SnapshotEndpoint: 'snapshotEndpoint',
+		}
+
+		// Iterate through each part and extract key-value pairs
+		for (const part of parts) {
+			const [key, value] = part.split('=')
+			if (key && value && keyMapping[key]) {
+				parsed[keyMapping[key]] = value
+			}
+		}
+
+		// Type assertion to ensure the parsed object conforms to the ConnectionString interface
+		if (!parsed.instrumentationKey) {
+			throw new Error('Invalid connection string format: missing instrumentationKey')
+		}
+
+		let ingestionEndpointBase = parsed.ingestionEndpoint // Connection strings have ending slash
+		if (!ingestionEndpointBase) {
+			if (parsed.endpointSuffix) {
+				ingestionEndpointBase = `https://dc.${parsed.endpointSuffix}/`
+			} else {
+				ingestionEndpointBase = this.DEFAULT_INGESTION_ENDPOINT_BASE
+			}
+		}
+
+		return new ApplicationInsightsConnection(parsed.instrumentationKey, `${ingestionEndpointBase}v2/track`)
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { ApplicationInsights, ApplicationInsightsOptions } from './ApplicationInsights'
-
+export { ApplicationInsightsConnection } from './ApplicationInsightsConnection'
 export { DataSanitizer } from './DataSanitizer'
 
 export { AvailabilityData } from './types/AvailabilityData'

--- a/test/BaseTestSuite.ts
+++ b/test/BaseTestSuite.ts
@@ -1,7 +1,8 @@
 import fetch from 'node-fetch'
 
 import { expect } from 'testyts'
-import { ApplicationInsights } from '../src/ApplicationInsights'
+import { ApplicationInsights } from '../src'
+import { ApplicationInsightsConnection } from '../src/ApplicationInsightsConnection'
 
 // Emulate cloudflare environment
 globalThis.fetch = fetch
@@ -12,11 +13,15 @@ export class BaseTestSuite {
 	public successResultString : string
 
 	constructor() {
+		if (!process.env.AI_IKEY) {
+			throw new Error('No instrumentation key set in environment')
+		}
+
 		this.appInsights = new ApplicationInsights({
 			context: {
 				'ai.operation.id': 'f523edf9-30dc-4ca7-8d37-6bfc2ed287d7',
 			},
-			connection: {instrumentationKey: 'a08f3f2d-9884-4437-b6ec-c835d3d58d82'}
+			connection: ApplicationInsightsConnection.fromConnectionString(`InstrumentationKey=${process.env.AI_IKEY};`),
 		})
 		this.successResultString = '{"itemsReceived":1,"itemsAccepted":1,"errors":[]}'
 	}

--- a/test/BaseTestSuite.ts
+++ b/test/BaseTestSuite.ts
@@ -13,15 +13,11 @@ export class BaseTestSuite {
 	public successResultString : string
 
 	constructor() {
-		if (!process.env.AI_IKEY) {
-			throw new Error('No instrumentation key set in environment')
-		}
-
 		this.appInsights = new ApplicationInsights({
 			context: {
 				'ai.operation.id': 'f523edf9-30dc-4ca7-8d37-6bfc2ed287d7',
 			},
-			connection: ApplicationInsightsConnection.fromConnectionString(`InstrumentationKey=${process.env.AI_IKEY};`),
+			connection: ApplicationInsightsConnection.fromConnectionString('InstrumentationKey=yourinstrumentationkey;'),
 		})
 		this.successResultString = '{"itemsReceived":1,"itemsAccepted":1,"errors":[]}'
 	}

--- a/test/BaseTestSuite.ts
+++ b/test/BaseTestSuite.ts
@@ -16,7 +16,7 @@ export class BaseTestSuite {
 			context: {
 				'ai.operation.id': 'f523edf9-30dc-4ca7-8d37-6bfc2ed287d7',
 			},
-			instrumentationKey: 'a08f3f2d-9884-4437-b6ec-c835d3d58d82', // Replace with your own instrumentationKey
+			connection: {instrumentationKey: 'a08f3f2d-9884-4437-b6ec-c835d3d58d82'}
 		})
 		this.successResultString = '{"itemsReceived":1,"itemsAccepted":1,"errors":[]}'
 	}

--- a/test/TestAvailability.ts
+++ b/test/TestAvailability.ts
@@ -7,8 +7,6 @@ import { AvailabilityData } from '../src'
 
 @TestSuite()
 export class TestAvailability extends BaseTestSuite {
-	public appInsights: ApplicationInsights
-
 	@Test()
 	async testMinimalAvailability() {
 		const request = new AvailabilityData({

--- a/test/TestConnectionStringParser.ts
+++ b/test/TestConnectionStringParser.ts
@@ -1,0 +1,37 @@
+import {
+	TestSuite, Test,
+	expect,
+} from 'testyts'
+import { ApplicationInsights } from '../src/ApplicationInsights'
+import { BaseTestSuite } from './BaseTestSuite'
+import { AvailabilityData } from '../src'
+import { ApplicationInsightsConnection } from '../src/ApplicationInsightsConnection'
+
+@TestSuite()
+export class ApplicationInsightsConnectionTests {
+	private static DEFAULT_AI_INGEST_ENDPOINT = 'https://dc.applicationinsights.azure.com/v2/track'
+
+	@Test()
+	public validConnectionStringWithAllProperties() {
+		const connectionString = 'InstrumentationKey=12345;IngestionEndpoint=https://ingest.example.com/;LiveEndpoint=https://live.example.com/;ProfilerEndpoint=https://profiler.example.com/;SnapshotEndpoint=https://snapshot.example.com/'
+		const connection = ApplicationInsightsConnection.fromConnectionString(connectionString)
+		expect.toBeEqual(connection.instrumentationKey, '12345')
+		expect.toBeEqual(connection.fullIngestionEndpoint, 'https://ingest.example.com/v2/track')
+	}
+
+	@Test()
+	public validConnectionStringWithEndpointSuffix() {
+		const connectionString = 'InstrumentationKey=12345;EndpointSuffix=example.com'
+		const connection = ApplicationInsightsConnection.fromConnectionString(connectionString)
+		expect.toBeEqual(connection.instrumentationKey, '12345')
+		expect.toBeEqual(connection.fullIngestionEndpoint, 'https://dc.example.com/v2/track')
+	}
+
+	@Test()
+	public onlyInstrumentationKeyUsesDefaultIngestEndpoint() {
+		const connectionString = 'InstrumentationKey=12345'
+		const connection = ApplicationInsightsConnection.fromConnectionString(connectionString)
+		expect.toBeEqual(connection.instrumentationKey, '12345')
+		expect.toBeEqual(connection.fullIngestionEndpoint, ApplicationInsightsConnectionTests.DEFAULT_AI_INGEST_ENDPOINT)
+	}
+}

--- a/test/TestConnectionStringParser.ts
+++ b/test/TestConnectionStringParser.ts
@@ -2,9 +2,6 @@ import {
 	TestSuite, Test,
 	expect,
 } from 'testyts'
-import { ApplicationInsights } from '../src/ApplicationInsights'
-import { BaseTestSuite } from './BaseTestSuite'
-import { AvailabilityData } from '../src'
 import { ApplicationInsightsConnection } from '../src/ApplicationInsightsConnection'
 
 @TestSuite()

--- a/test/TestDependency.ts
+++ b/test/TestDependency.ts
@@ -7,8 +7,6 @@ import { RemoteDependencyData } from '../src'
 
 @TestSuite()
 export class TestDependency extends BaseTestSuite {
-	public appInsights: ApplicationInsights
-
 	@Test()
 	async testMinimalRemoteDependency() {
 		const request = new RemoteDependencyData({

--- a/test/TestEvent.ts
+++ b/test/TestEvent.ts
@@ -7,8 +7,6 @@ import { EventData } from '../src'
 
 @TestSuite()
 export class TestEvent extends BaseTestSuite {
-	public appInsights: ApplicationInsights
-
 	@Test()
 	async testMinimalEvent() {
 		const request = new EventData({

--- a/test/TestException.ts
+++ b/test/TestException.ts
@@ -7,8 +7,6 @@ import { ExceptionData, SeverityLevel } from '../src'
 
 @TestSuite()
 export class TestException extends BaseTestSuite {
-	public appInsights: ApplicationInsights
-
 	@Test()
 	async testMinimalException() {
 		const request = new ExceptionData({

--- a/test/TestMessage.ts
+++ b/test/TestMessage.ts
@@ -7,8 +7,6 @@ import { MessageData, SeverityLevel } from '../src'
 
 @TestSuite()
 export class TestMessage extends BaseTestSuite {
-	public appInsights: ApplicationInsights
-
 	@Test()
 	async testMinimalMessage() {
 		const request = new MessageData({

--- a/test/TestMetric.ts
+++ b/test/TestMetric.ts
@@ -7,8 +7,6 @@ import { MetricData, DataPoint, DataPointType } from '../src'
 
 @TestSuite()
 export class TestMetric extends BaseTestSuite {
-	public appInsights: ApplicationInsights
-
 	@Test()
 	async testMinimalMetric() {
 		const request = new MetricData({

--- a/test/TestPageView.ts
+++ b/test/TestPageView.ts
@@ -7,8 +7,6 @@ import { PageViewPerfData } from '../src'
 
 @TestSuite()
 export class TestPageView extends BaseTestSuite {
-	public appInsights: ApplicationInsights
-
 	@Test()
 	async testMinimalPageViewPerf() {
 		const request = new PageViewPerfData({

--- a/test/TestRequest.ts
+++ b/test/TestRequest.ts
@@ -7,8 +7,6 @@ import { BaseTestSuite } from './BaseTestSuite'
 
 @TestSuite()
 export class TestRequest extends BaseTestSuite {
-	public appInsights: ApplicationInsights
-
 	@Test()
 	async testMinimalRequest() {
 		const request = new RequestData({

--- a/testy.json
+++ b/testy.json
@@ -1,3 +1,1 @@
-{
-  "include": ["test/**.ts"]
-}
+{"include":["test/*.ts"]}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,10 @@
 		"sourceMap": true,
 		"alwaysStrict": true,
 		"allowJs": true,
-		"checkJs": true
 	},
 	"exclude": [
 		"node_modules",
 		"dist",
+		"test"
 	],
 }


### PR DESCRIPTION
Application Insights will EOL instrumentation keys soon, so I added some (very basic) support for connection strings in this fork. I published this as new NPM package already but feel free to merge this into the original! It's a pretty old package and if I had the time I would also update it completely to latest typescript version :).